### PR TITLE
Correctly use `<div>`s

### DIFF
--- a/css/bootstrap.css
+++ b/css/bootstrap.css
@@ -4115,12 +4115,8 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
   border-top-right-radius: 0;
 }
 .navbar {
-  position: fixed;
-  top:0;
-  left:0;
   width:100%;
   min-height:80px;
-  margin-bottom: 20px;
   z-index:999;
   border: 1px solid transparent;
 }

--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
 <body data-gr-c-s-loaded="true">
 
 <div id="includedNav"></div>
-<div style="height: 60px;"></div>
 	
 	
 <div class="container-fluid index about">

--- a/publications.html
+++ b/publications.html
@@ -21,8 +21,6 @@
 <body data-gr-c-s-loaded="true">
 <div id="includedNav"></div>
 	
-<div style="height: 60px;"></div>
-	
 <div class="container-fluid index ">
   <div class="container"> 
   <span><div class="refs-row">
@@ -671,7 +669,6 @@ From the Inside Out: Organizational Impact on Open-Source Communities and Womenâ
 
 
 
-<div style="height: 20px;"></div>
 
 <div class="container-fluid footer">
   <div class="container">


### PR DESCRIPTION
Hi, I noticed that your header was partially hiding your publications list. I checked the HTML and noted you used a sort-of-a-hack to shift down the content of your main content. 

<img width="624" alt="pub" src="https://github.com/user-attachments/assets/2a88ce87-014b-4f30-8aad-7803c3b9877b" />

This PR fixed this issue by restoring the original `position` of `.navbar` and removing the `<div>`s with hardcoded height. 

Check https://naramsim.github.io/sophieball.github.io/publications.html . Please note that when the width of the browser is less than 768px the menu, when opened, shifts the content down instead of extending over it. 